### PR TITLE
fix: correct cash flow signs and filter zero bond_value operations

### DIFF
--- a/src/tddata/analytics.py
+++ b/src/tddata/analytics.py
@@ -264,6 +264,13 @@ def calculate_operations_returns(
     if operations.height == 0:
         return pl.DataFrame()
 
+    # Filter out operations with zero bond value
+    if C.BOND_VALUE.value in operations.columns:
+        operations = operations.filter(pl.col(C.BOND_VALUE.value) != 0)
+
+    if operations.height == 0:
+        return pl.DataFrame()
+
     if current_date is None:
         current_date = date.today()
     current_date_dt = datetime(current_date.year, current_date.month, current_date.day)
@@ -593,7 +600,7 @@ def calculate_portfolio_monthly_returns(
             key = (bond_type, mat)
 
             if op_type == OperationType.BUY.value:
-                net_cash_flow -= value
+                net_cash_flow += value
                 if key not in positions:
                     positions[key] = {"quantity": 0.0, "avg_cost": 0.0}
                 old_qty = positions[key]["quantity"]
@@ -603,7 +610,7 @@ def calculate_portfolio_monthly_returns(
                 positions[key]["quantity"] = new_qty
 
             elif op_type == OperationType.SELL.value:
-                net_cash_flow += value
+                net_cash_flow -= value
                 if key in positions:
                     positions[key]["quantity"] -= abs(qty)
                     if positions[key]["quantity"] <= 0:
@@ -640,7 +647,7 @@ def calculate_portfolio_monthly_returns(
                             ):
                                 coupon_income += positions.get(key, {}).get("quantity", 0.0) * unit_price
 
-        net_cash_flow += coupon_income
+        net_cash_flow -= coupon_income
 
         # Calculate EMV (Ending Market Value) using month_end prices
         emv = 0.0


### PR DESCRIPTION
- In calculate_operations_returns: filter out rows where bond_value == 0 to avoid counting phantom positions with no real investment value
- In calculate_portfolio_monthly_returns: fix net_cash_flow sign convention so that buys are positive (inflows) and sells/coupon distributions are negative (outflows), consistent with the Modified Dietz return formula

Fixes test_zero_bond_value_filtered, test_cash_flow_tracking, test_coupon_as_distribution_portfolio, and test_zero_bond_value_filtered_portfolio.

https://claude.ai/code/session_01Y6RXCgFXAftmK9LsPdiPUz